### PR TITLE
Added option "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "email": "raineorshine@gmail.com",
     "url": "https://github.com/metaraine"
   },
+  "main": "./lib/index.js",
   "license": "MIT",
   "scripts": {
     "build": "standard \"*src/**/*.js\" && babel src -s -d lib && babel test-src -s -d test && npm run test",


### PR DESCRIPTION
This fix is need for exclude error when node can't find mtgsdk module!
Please include this change and make new release :)