### PR TITLE
Fulfill Promise Obligation

### DIFF
--- a/src/querybuilder.js
+++ b/src/querybuilder.js
@@ -40,6 +40,7 @@ module.exports = type => ({
             return getEmit(type, page + 1, args) // RECURSION
           } else {
             emitter.trigger('end')
+            return
           }
         })
         .catch(err => emitter.trigger('error', err))

--- a/src/querybuilder.js
+++ b/src/querybuilder.js
@@ -40,7 +40,7 @@ module.exports = type => ({
             return getEmit(type, page + 1, args) // RECURSION
           } else {
             emitter.trigger('end')
-            return
+            return null
           }
         })
         .catch(err => emitter.trigger('error', err))


### PR DESCRIPTION
I tried to pull all cards by set and received this warning message once per set: 

(node:7904) Warning: a promise was created in a handler at packages/meteor.js:1356:24 but was not returned from it, see http://goo.gl/rRqMUw at new Promise (/Users/beauregard/meteor/to-do-app/simple-todos/node_modules/bluebird/js/release/promise.js:79:10)

I believe adding the "return null"  in this request will resolve the warning message.